### PR TITLE
standalone-install.sh script improvements

### DIFF
--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -74,7 +74,7 @@ then
       exit 1
     fi
   fi
-se
+else
   echo "Go version $go_version found: $(which go)"
 fi
 

--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# VERSION 0.3 by d3vilh@github.com aka Mr. Philipp.
+# VERSION 0.2 by d3vilh@github.com aka Mr. Philipp.
 #
 
 # All the variables
-GOVERSION="1.22.3"
+GOVERSION="1.21.5"
 
 # Description
 echo "This script will install OpenVPN-UI and all the dependencies on your local environment. No containers will be used."
@@ -15,6 +15,17 @@ then
     exit 1
 fi
 
+# Prevent running as root or via sudo (because go might not be found in PATH when done so)
+if [ "$EUID" -eq 0 ]; then
+  echo "Warning: You are not running this script with sudo/root. Some steps may fail."
+  read -p "Do you want to continue anyway? (y/n): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Exiting to avoid running as root."
+    exit 1
+  fi
+fi
+
 # Check if Go is installed and the version is supported
 go_version=$(go version 2>/dev/null | awk '{print $3}' | tr -d "go")
 if [[ -z "$go_version" || "$go_version" < $GOVERSION ]]
@@ -24,28 +35,34 @@ then
     echo    # move to a new line
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-        # Check the architecture of the machine
-        arch=$(uname -m)
-        if [[ "$arch" == "x86_64" ]]; then
-            # Install Go for x86_64
-            wget https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz
-        elif [[ "$arch" == "aarch64" ]]; then
-            # Install Go for arm64
-            wget https://golang.org/dl/go${GOVERSION}.linux-arm64.tar.gz
-            sudo tar -C /usr/local -xzf go${GOVERSION}.linux-arm64.tar.gz
-        elif [[ "$arch" == "armv7l" ]]; then
-            # Install Go for armv7l
-            wget https://golang.org/dl/go${GOVERSION}.linux-armv7l.tar.gz
-            sudo tar -C /usr/local -xzf go${GOVERSION}.linux-armv7l.tar.gz
-        elif [[ "$arch" == "armv6l" ]]; then
-            # Install Go for armv6l
-            wget https://golang.org/dl/go${GOVERSION}.linux-armv6l.tar.gz
-            sudo tar -C /usr/local -xzf go${GOVERSION}.linux-armv6l.tar.gz
-        else
-            echo "Unsupported architecture."
-            exit 1
-        fi
+        # Install Go
+	
+		arch=$(uname -m)
+		case "$arch" in
+		  x86_64)
+			goarch="amd64"
+			;;
+		  aarch64 | arm64)
+			goarch="arm64"
+			;;
+		  armv6l | armv7l)
+			goarch="armv6l"  # Note: Go provides only armv6l binary which works for armv7 too
+			;;
+		  *)
+			echo "Unsupported architecture: $arch"
+			exit 1
+			;;
+		esac
+
+		gofile="go${GOVERSION}.linux-${goarch}.tar.gz"
+		gourl="https://go.dev/dl/${gofile}"
+
+		echo "Detected architecture: $arch → downloading $gourl"
+
+		wget -q --show-progress "$gourl" || { echo "Failed to download $gofile"; exit 1; }
+		sudo tar -C /usr/local -xzf "$gofile"
+		rm "$gofile"
+
         export PATH=$PATH:/usr/local/go/bin
         echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bashrc
         source ~/.bashrc
@@ -58,6 +75,8 @@ then
             exit 1
         fi
     fi
+else
+	echo "Go version $go_version found: $(which go)"
 fi
 
 # Update your system
@@ -107,8 +126,13 @@ then
     # Install OpenVPN-UI and qrencode
     echo "Installing OpenVPN-UI and qrencode"
     source ~/.bashrc # reload bashrc to get bee command
-    echo "Cloning qrencode into build directory"
-    git clone https://github.com/d3vilh/qrencode
+	
+	if [ -d "qrencode" ]; then
+		echo "Directory 'qrencode' already exists. Skipping git clone."
+	else
+		echo "Cloning qrencode into build directory"
+		git clone https://github.com/d3vilh/qrencode
+	fi
 
     # Set environment variables
     export GO111MODULE='auto'
@@ -116,7 +140,8 @@ then
     export CC=musl-gcc 
 
     # Packing openvpn-ui
-    cd ../
+	CURPATH=$(pwd)
+	cd ../
     echo "Building and packing OpenVPN-UI"
     # Execute bee pack
     export PATH=$PATH:$(go env GOPATH)/bin
@@ -131,8 +156,8 @@ then
     go build -o qrencode main.go
     chmod +x qrencode
     echo "Moving qrencode to GOPATH"
-    mv qrencode $(go env GOPATH)/bin
-    cd ../
+    mv -v qrencode $(go env GOPATH)/bin
+    cd $CURPATH
 fi
 
 printf "\033[1;34mAll done.\033[0m\n"

--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -12,7 +12,7 @@ read -p "Do you want to continue? (y/n)" -n 1 -r
 echo    # move to a new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
-    exit 1
+  exit 1
 fi
 
 # Prevent running as root or via sudo (because go might not be found in PATH when done so)
@@ -30,14 +30,13 @@ fi
 go_version=$(go version 2>/dev/null | awk '{print $3}' | tr -d "go")
 if [[ -z "$go_version" || "$go_version" < $GOVERSION ]]
 then
-    echo "Golang version ${GOVERSION} is not installed."
-    read -p "Would you like to install it? (y/n) " -n 1 -r
-    echo    # move to a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        # Install Go
-  
-    arch=$(uname -m)
+  echo "Golang version ${GOVERSION} is not installed."
+  read -p "Would you like to install it? (y/n) " -n 1 -r
+  echo    # move to a new line
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    # Install Go
+    arch=$(uname -m) # detect current target system's architecture
     case "$arch" in
       x86_64)
       goarch="amd64"
@@ -53,29 +52,29 @@ then
       exit 1
       ;;
     esac
-
+  
     gofile="go${GOVERSION}.linux-${goarch}.tar.gz"
     gourl="https://go.dev/dl/${gofile}"
-
+  
     echo "Detected architecture: $arch → downloading $gourl"
-
+  
     wget -q --show-progress "$gourl" || { echo "Failed to download $gofile"; exit 1; }
     sudo tar -C /usr/local -xzf "$gofile"
     rm "$gofile"
 
-        export PATH=$PATH:/usr/local/go/bin
-        echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bashrc
-        source ~/.bashrc
-    else
-        read -p "Would you like to continue without Golang ${GOVERSION} installation? (y/n) " -n 1 -r
-        echo    # move to a new line
-        if [[ ! $REPLY =~ ^[Yy]$ ]]
-        then
-            echo "Installation terminated by user."
-            exit 1
-        fi
+    export PATH=$PATH:/usr/local/go/bin
+    echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bashrc
+    source ~/.bashrc
+  else
+    read -p "Would you like to continue without Golang ${GOVERSION} installation? (y/n) " -n 1 -r
+    echo    # move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+      echo "Installation terminated by user."
+      exit 1
     fi
-else
+  fi
+se
   echo "Go version $go_version found: $(which go)"
 fi
 
@@ -84,9 +83,9 @@ read -p "Would you like to run apt-get update? (y/n) " -n 1 -r
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # Update your system
-    echo "Updating current environment with apt-get update"
-    sudo apt-get update -y
+  # Update your system
+  echo "Updating current environment with apt-get update"
+  sudo apt-get update -y
 fi
 
 # Install necessary tools
@@ -94,9 +93,9 @@ read -p "Would you like to install the dependencies (sed, gcc, git, musl-tools, 
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # Install necessary tools
-    echo "Installing dependencies (sed, gcc, git, musl-tools, easy-rsa, curl, jq, oathtool)"
-    sudo apt-get install -y sed gcc git musl-tools easy-rsa curl jq oathtool
+  # Install necessary tools
+  echo "Installing dependencies (sed, gcc, git, musl-tools, easy-rsa, curl, jq, oathtool)"
+  sudo apt-get install -y sed gcc git musl-tools easy-rsa curl jq oathtool
 fi
 
 # Go Modules download
@@ -104,18 +103,18 @@ read -p "Would you like to download all necessary Go modules? (y/n) " -n 1 -r
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # Download all Go modules
-    echo "Downloading all Go modules (go mod download)"
-    go mod download
+  # Download all Go modules
+  echo "Downloading all Go modules (go mod download)"
+  go mod download
 fi
 
 read -p "Would you like to install Beego v2? (y/n) " -n 1 -r
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # Install Beego
-    echo "Installing BeeGo v2"
-    go install github.com/beego/bee/v2@develop
+  # Install Beego
+  echo "Installing BeeGo v2"
+  go install github.com/beego/bee/v2@develop
 fi
 
 # Installing OpenVPN-UI and qrencode
@@ -123,10 +122,10 @@ read -p "Would you like to build OpenVPN-UI and qrencode binaries? (y/n) " -n 1 
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # Install OpenVPN-UI and qrencode
-    echo "Installing OpenVPN-UI and qrencode"
-    source ~/.bashrc # reload bashrc to get bee command
-  
+  # Install OpenVPN-UI and qrencode
+  echo "Installing OpenVPN-UI and qrencode"
+  source ~/.bashrc # reload bashrc to get bee command
+
   if [ -d "qrencode" ]; then
     echo "Directory 'qrencode' already exists. Skipping git clone."
   else
@@ -134,30 +133,30 @@ then
     git clone https://github.com/d3vilh/qrencode
   fi
 
-    # Set environment variables
-    export GO111MODULE='auto'
-    export CGO_ENABLED=1
-    export CC=musl-gcc 
+  # Set environment variables
+  export GO111MODULE='auto'
+  export CGO_ENABLED=1
+  export CC=musl-gcc 
 
-    # Packing openvpn-ui
+  # Packing openvpn-ui
   CURPATH=$(pwd)
   cd ../
-    echo "Building and packing OpenVPN-UI"
-    # Execute bee pack
-    export PATH=$PATH:$(go env GOPATH)/bin
-    go env -w GOFLAGS="-buildvcs=false"
-    source ~/.bashrc
-    bee version
-    bee pack -exr='^vendor|^ace.tar.bz2|^data.db|^build|^README.md|^docs'
+  echo "Building and packing OpenVPN-UI"
+  # Execute bee pack
+  export PATH=$PATH:$(go env GOPATH)/bin
+  go env -w GOFLAGS="-buildvcs=false"
+  source ~/.bashrc
+  bee version
+  bee pack -exr='^vendor|^ace.tar.bz2|^data.db|^build|^README.md|^docs'
 
-    # Build qrencode
-    echo "Building qrencode"
-    cd build/qrencode
-    go build -o qrencode main.go
-    chmod +x qrencode
-    echo "Moving qrencode to GOPATH"
-    mv -v qrencode $(go env GOPATH)/bin
-    cd $CURPATH
+  # Build qrencode
+  echo "Building qrencode"
+  cd build/qrencode
+  go build -o qrencode main.go
+  chmod +x qrencode
+  echo "Moving qrencode to GOPATH"
+  mv -v qrencode $(go env GOPATH)/bin
+  cd $CURPATH
 fi
 
 printf "\033[1;34mAll done.\033[0m\n"

--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# VERSION 0.2 by d3vilh@github.com aka Mr. Philipp.
+# VERSION 0.4 by damian@bytefarm.ch
 #
 
 # All the variables

--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -39,17 +39,17 @@ then
     arch=$(uname -m) # detect current target system's architecture
     case "$arch" in
       x86_64)
-      goarch="amd64"
-      ;;
+        goarch="amd64"
+        ;;
       aarch64 | arm64)
-      goarch="arm64"
-      ;;
+        goarch="arm64"
+        ;;
       armv6l | armv7l)
-      goarch="armv6l"  # Note: Go provides only armv6l binary which works for armv7 too
-      ;;
+        goarch="armv6l"  # Note: Go provides only armv6l binary which works for armv7 too
+        ;;
       *)
-      echo "Unsupported architecture: $arch"
-      exit 1
+        echo "Unsupported architecture: $arch"
+        exit 1
       ;;
     esac
   

--- a/build/standalone-install.sh
+++ b/build/standalone-install.sh
@@ -36,32 +36,32 @@ then
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
         # Install Go
-	
-		arch=$(uname -m)
-		case "$arch" in
-		  x86_64)
-			goarch="amd64"
-			;;
-		  aarch64 | arm64)
-			goarch="arm64"
-			;;
-		  armv6l | armv7l)
-			goarch="armv6l"  # Note: Go provides only armv6l binary which works for armv7 too
-			;;
-		  *)
-			echo "Unsupported architecture: $arch"
-			exit 1
-			;;
-		esac
+  
+    arch=$(uname -m)
+    case "$arch" in
+      x86_64)
+      goarch="amd64"
+      ;;
+      aarch64 | arm64)
+      goarch="arm64"
+      ;;
+      armv6l | armv7l)
+      goarch="armv6l"  # Note: Go provides only armv6l binary which works for armv7 too
+      ;;
+      *)
+      echo "Unsupported architecture: $arch"
+      exit 1
+      ;;
+    esac
 
-		gofile="go${GOVERSION}.linux-${goarch}.tar.gz"
-		gourl="https://go.dev/dl/${gofile}"
+    gofile="go${GOVERSION}.linux-${goarch}.tar.gz"
+    gourl="https://go.dev/dl/${gofile}"
 
-		echo "Detected architecture: $arch → downloading $gourl"
+    echo "Detected architecture: $arch → downloading $gourl"
 
-		wget -q --show-progress "$gourl" || { echo "Failed to download $gofile"; exit 1; }
-		sudo tar -C /usr/local -xzf "$gofile"
-		rm "$gofile"
+    wget -q --show-progress "$gourl" || { echo "Failed to download $gofile"; exit 1; }
+    sudo tar -C /usr/local -xzf "$gofile"
+    rm "$gofile"
 
         export PATH=$PATH:/usr/local/go/bin
         echo "export PATH=$PATH:$(go env GOPATH)/bin" >> ~/.bashrc
@@ -76,7 +76,7 @@ then
         fi
     fi
 else
-	echo "Go version $go_version found: $(which go)"
+  echo "Go version $go_version found: $(which go)"
 fi
 
 # Update your system
@@ -126,13 +126,13 @@ then
     # Install OpenVPN-UI and qrencode
     echo "Installing OpenVPN-UI and qrencode"
     source ~/.bashrc # reload bashrc to get bee command
-	
-	if [ -d "qrencode" ]; then
-		echo "Directory 'qrencode' already exists. Skipping git clone."
-	else
-		echo "Cloning qrencode into build directory"
-		git clone https://github.com/d3vilh/qrencode
-	fi
+  
+  if [ -d "qrencode" ]; then
+    echo "Directory 'qrencode' already exists. Skipping git clone."
+  else
+    echo "Cloning qrencode into build directory"
+    git clone https://github.com/d3vilh/qrencode
+  fi
 
     # Set environment variables
     export GO111MODULE='auto'
@@ -140,8 +140,8 @@ then
     export CC=musl-gcc 
 
     # Packing openvpn-ui
-	CURPATH=$(pwd)
-	cd ../
+  CURPATH=$(pwd)
+  cd ../
     echo "Building and packing OpenVPN-UI"
     # Execute bee pack
     export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
- added detection and warning when script is running as sudo/root because installationscript  might fail when ran as root due to PATH issues
- echo detected/found current go version with exact path to go binary for clarity
- add architecture string "arm64"
- cpu architecture detection simplyfied; no redundant wget and tar commands; case construct instead of if/elif/else
- fix: go does not provide any extra binaries for armv7l architecture; need to use compatible armv6l binariesas fallback instead
- print the detected unsupported architecture before script exit
- print output detected architecture and resulted archive file/url to be downloaded
- exit script with error message on wget download error
- remove downloaded archive file after archive extraction
- set go version back to 1.21.5 because install BeeGo v2 (go install github.com/beego/bee/v2@develop) would fail due to multiple build errors with the newer go version 1.22.3
- Cloning qrencode, check if path already exists to avoid git clone fatal error when already cloned