### PR TITLE
Add token-authenticated REST API for certificate management

### DIFF
--- a/build/assets/app.conf
+++ b/build/assets/app.conf
@@ -7,6 +7,8 @@ EnableAdmin = false
 sessionon = true
 CopyRequestBody = true
 AuthType = "password"
+; Override via Docker env OPENVPN_API_TOKEN
+ApiToken = "openvpn-ui-api-token"
 DbPath = "./db/data.db"
 EasyRsaPath = "/usr/share/easy-rsa"
 OpenVpnPath = "/etc/openvpn"

--- a/cmd/verify-api/main.go
+++ b/cmd/verify-api/main.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	base := flag.String("base", envOr("API_BASE", "http://localhost:8999"), "API base URL")
+	token := flag.String("token", envOr("OPENVPN_API_TOKEN", "openvpn-ui-api-token"), "API token")
+	name := flag.String("name", "", "certificate name for integration tests")
+	integration := flag.Bool("integration", false, "run create/renew/revoke/delete/download lifecycle")
+	flag.Parse()
+
+	if *name == "" {
+		*name = fmt.Sprintf("api-test-%d", time.Now().Unix())
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	runner := &runner{
+		client: client,
+		base:   strings.TrimRight(*base, "/"),
+		token:  *token,
+		name:   *name,
+	}
+
+	runner.runSmokeTests()
+
+	if *integration {
+		runner.runIntegrationTests()
+	} else {
+		fmt.Println("\n(skip integration tests, use -integration to enable)")
+	}
+
+	if runner.failed > 0 {
+		fmt.Printf("\n%d test(s) failed\n", runner.failed)
+		os.Exit(1)
+	}
+	fmt.Printf("\nall %d test(s) passed\n", runner.passed)
+}
+
+type runner struct {
+	client *http.Client
+	base   string
+	token  string
+	name   string
+	passed int
+	failed int
+}
+
+func (r *runner) runSmokeTests() {
+	fmt.Println("== smoke tests ==")
+	r.check("GET without token returns 401", func() error {
+		return r.expectStatus("GET", "/api/v1/certificates/smoke-missing", "", nil, 401)
+	})
+	r.check("GET with bad token returns 401", func() error {
+		return r.expectStatus("GET", "/api/v1/certificates/smoke-missing", "bad-token", nil, 401)
+	})
+	r.check("GET nonexistent cert returns 404", func() error {
+		return r.expectStatus("GET", "/api/v1/certificates/smoke-missing", r.token, nil, 404)
+	})
+	r.check("POST empty body returns 400", func() error {
+		return r.expectStatus("POST", "/api/v1/certificates", r.token, []byte(`{}`), 400)
+	})
+	r.check("POST renew unknown name returns 400", func() error {
+		return r.expectStatus("POST", "/api/v1/certificates/smoke-missing/renew", r.token, nil, 400)
+	})
+}
+
+func (r *runner) runIntegrationTests() {
+	fmt.Println("\n== integration tests ==")
+	r.check("POST create certificate", func() error {
+		body := []byte(fmt.Sprintf(`{"name":%q}`, r.name))
+		resp, err := r.do("POST", "/api/v1/certificates", r.token, body)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+		}
+		return nil
+	})
+	if r.failed > 0 {
+		fmt.Println("(skip remaining integration tests: create failed, PKI/scripts may be unavailable)")
+		return
+	}
+
+	r.check("GET download .ovpn", func() error {
+		resp, err := r.do("GET", "/api/v1/certificates/"+r.name, r.token, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+		}
+		if !strings.Contains(string(data), "client") && !strings.Contains(string(data), "remote") {
+			return fmt.Errorf("response does not look like an .ovpn file")
+		}
+		return nil
+	})
+
+	r.check("POST renew certificate", func() error {
+		return r.expectStatus("POST", "/api/v1/certificates/"+r.name+"/renew", r.token, nil, 200)
+	})
+	r.check("POST revoke certificate", func() error {
+		return r.expectStatus("POST", "/api/v1/certificates/"+r.name+"/revoke", r.token, nil, 200)
+	})
+	r.check("DELETE certificate", func() error {
+		return r.expectStatus("DELETE", "/api/v1/certificates/"+r.name, r.token, nil, 200)
+	})
+}
+
+func (r *runner) check(name string, fn func() error) {
+	err := fn()
+	if err != nil {
+		r.fail(name, err)
+		return
+	}
+	r.pass(name)
+}
+
+func (r *runner) pass(name string) {
+	r.passed++
+	fmt.Printf("  PASS  %s\n", name)
+}
+
+func (r *runner) fail(name string, err error) {
+	r.failed++
+	fmt.Printf("  FAIL  %s: %v\n", name, err)
+}
+
+func (r *runner) expectStatus(method, path, token string, body []byte, want int) error {
+	resp, err := r.do(method, path, token, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != want {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("want HTTP %d, got %d: %s", want, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+func (r *runner) do(method, path, token string, body []byte) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, r.base+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return r.client.Do(req)
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -7,6 +7,8 @@ SessionOn = true
 CopyRequestBody = true
 DbPath = "./db/data.db"
 AuthType = "password"
+; Override via Docker env OPENVPN_API_TOKEN
+ApiToken = "openvpn-ui-api-token"
 ; LdapAddress = "localhost:389"
 ; LdapDn = "cn=%s,ou=users,dc=syncloud,dc=org"
 ; plain/tls/starttls

--- a/controllers/api-base.go
+++ b/controllers/api-base.go
@@ -1,11 +1,85 @@
 package controllers
 
 import (
+	"os"
+	"strings"
+
 	"github.com/beego/beego/v2/core/logs"
+	"github.com/beego/beego/v2/server/web"
 )
 
 type APIBaseController struct {
 	BaseController
+}
+
+type APITokenController struct {
+	web.Controller
+}
+
+func (c *APITokenController) Prepare() {
+	c.EnableXSRF = false
+	if !c.validateToken() {
+		c.serveUnauthorized()
+	}
+}
+
+func (c *APITokenController) validateToken() bool {
+	apiToken := getAPIToken()
+	if apiToken == "" {
+		logs.Warning("ApiToken is not configured")
+		return false
+	}
+
+	auth := c.Ctx.Input.Header("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ") == apiToken
+	}
+	return c.Ctx.Input.Header("X-API-Token") == apiToken
+}
+
+func getAPIToken() string {
+	if v := os.Getenv("OPENVPN_API_TOKEN"); v != "" {
+		return v
+	}
+	apiToken, err := web.AppConfig.String("ApiToken")
+	if err != nil {
+		return ""
+	}
+	return apiToken
+}
+
+func (c *APITokenController) serveUnauthorized() {
+	c.Ctx.Output.SetStatus(401)
+	c.Data["json"] = JSONResponse{
+		Status:  "error",
+		Message: "Unauthorized",
+	}
+	c.ServeJSON()
+	c.StopRun()
+}
+
+func (c *APITokenController) ServeJSONMessage(message string) {
+	r := NewJSONResponse()
+	r.Message = message
+	c.Data["json"] = r
+	c.ServeJSON()
+}
+
+func (c *APITokenController) ServeJSONData(data interface{}) {
+	r := NewJSONResponse()
+	r.Data = data
+	c.Data["json"] = r
+	c.ServeJSON()
+}
+
+func (c *APITokenController) ServeJSONError(message string) {
+	c.Data["json"] = JSONResponse{
+		Status:  "error",
+		Message: message,
+	}
+	logs.Warning(message)
+	c.Ctx.Output.SetStatus(400)
+	c.ServeJSON()
 }
 
 // JSONResponse http://stackoverflow.com/a/12979961

--- a/controllers/api-certificates.go
+++ b/controllers/api-certificates.go
@@ -1,0 +1,333 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/beego/beego/v2/core/logs"
+	"github.com/beego/beego/v2/core/validation"
+	clientconfig "github.com/d3vilh/openvpn-server-config/client/client-config"
+	"github.com/d3vilh/openvpn-ui/lib"
+	"github.com/d3vilh/openvpn-ui/models"
+	"github.com/d3vilh/openvpn-ui/state"
+)
+
+// APICertificatesController provides token-authenticated certificate management API.
+type APICertificatesController struct {
+	APITokenController
+	ConfigDir string
+}
+
+// APICreateCertRequest holds parameters for certificate creation.
+type APICreateCertRequest struct {
+	Name       string `json:"name" valid:"Required;"`
+	StaticIP   string `json:"staticip"`
+	Passphrase string `json:"passphrase"`
+	ExpireDays string `json:"expire_days"`
+	Email      string `json:"email"`
+	Country    string `json:"country"`
+	Province   string `json:"province"`
+	City       string `json:"city"`
+	Org        string `json:"org"`
+	OrgUnit    string `json:"org_unit"`
+	TFAName    string `json:"tfa_name"`
+	TFAIssuer  string `json:"tfa_issuer"`
+}
+
+// Get downloads the .ovpn client configuration for a certificate.
+// @Title Get certificate
+// @Description Download OpenVPN client configuration (.ovpn)
+// @Param    name     path     string     true      "Certificate name"
+// @Success 200 file download
+// @Failure 400 request failure
+// @Failure 401 unauthorized
+// @Failure 404 certificate not found
+// @router /:name [get]
+func (c *APICertificatesController) Get() {
+	name := c.GetString(":name")
+	if name == "" {
+		c.ServeJSONError("name is required")
+		return
+	}
+
+	cfgPath, err := apiSaveClientOVPN(c.ConfigDir, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.Ctx.Output.SetStatus(404)
+			c.Data["json"] = JSONResponse{Status: "error", Message: "Certificate not found"}
+			c.ServeJSON()
+			return
+		}
+		c.ServeJSONError(err.Error())
+		return
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.Ctx.Output.SetStatus(404)
+			c.Data["json"] = JSONResponse{Status: "error", Message: "Certificate not found"}
+			c.ServeJSON()
+			return
+		}
+		c.ServeJSONError(err.Error())
+		return
+	}
+
+	filename := name + ".ovpn"
+	c.Ctx.Output.Header("Content-Type", "application/x-openvpn-profile")
+	c.Ctx.Output.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	c.Ctx.Output.Body(data)
+}
+
+// Create creates a new client certificate.
+// @Title Create certificate
+// @Description Create a new OpenVPN client certificate
+// @Param    body     body     controllers.APICreateCertRequest     true      "Certificate parameters"
+// @Success 200 request success
+// @Failure 400 request failure
+// @Failure 401 unauthorized
+// @router / [post]
+func (c *APICertificatesController) Create() {
+	req := APICreateCertRequest{}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	if err := c.fillCreateDefaults(&req); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	if err := validateAPICreateCert(req); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+
+	logs.Info("API: Creating certificate: name=%s", req.Name)
+	if err := lib.CreateCertificate(
+		req.Name, req.StaticIP, req.Passphrase, req.ExpireDays,
+		req.Email, req.Country, req.Province,
+		strconv.Quote(req.City), strconv.Quote(req.Org), strconv.Quote(req.OrgUnit),
+		req.TFAName, req.TFAIssuer,
+	); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	c.ServeJSONMessage("Certificate \"" + req.Name + "\" has been created")
+}
+
+// Renew renews an existing client certificate.
+// @Title Renew certificate
+// @Description Renew an existing OpenVPN client certificate
+// @Param    name     path     string     true      "Certificate name"
+// @Success 200 request success
+// @Failure 400 request failure
+// @Failure 401 unauthorized
+// @router /:name/renew [post]
+func (c *APICertificatesController) Renew() {
+	name := c.GetString(":name")
+	cert, err := lib.FindActiveCertByName(name)
+	if err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	localip := ""
+	if cert.Details != nil {
+		localip = cert.Details.LocalIP
+	}
+
+	logs.Info("API: Renewing certificate: name=%s serial=%s", name, cert.Serial)
+	if err := lib.RenewCertificate(name, localip, cert.Serial, certTFAName(cert)); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	c.ServeJSONMessage("Certificate \"" + name + "\" has been renewed")
+}
+
+// Revoke revokes a client certificate.
+// @Title Revoke certificate
+// @Description Revoke an OpenVPN client certificate
+// @Param    name     path     string     true      "Certificate name"
+// @Success 200 request success
+// @Failure 400 request failure
+// @Failure 401 unauthorized
+// @router /:name/revoke [post]
+func (c *APICertificatesController) Revoke() {
+	name := c.GetString(":name")
+	revoked := false
+	for i := 0; i < 5; i++ {
+		cert, err := lib.FindActiveCertByName(name)
+		if err != nil {
+			break
+		}
+		logs.Info("API: Revoking certificate: name=%s serial=%s", name, cert.Serial)
+		if err := lib.RevokeCertificate(name, cert.Serial, certTFAName(cert)); err != nil {
+			c.ServeJSONError(err.Error())
+			return
+		}
+		revoked = true
+	}
+	if !revoked {
+		c.ServeJSONError(fmt.Sprintf("active certificate for %q not found", name))
+		return
+	}
+	c.ServeJSONMessage("Certificate \"" + name + "\" has been revoked")
+}
+
+// Delete permanently removes a revoked client certificate.
+// @Title Delete certificate
+// @Description Permanently remove a revoked OpenVPN client certificate
+// @Param    name     path     string     true      "Certificate name"
+// @Success 200 request success
+// @Failure 400 request failure
+// @Failure 401 unauthorized
+// @router /:name [delete]
+func (c *APICertificatesController) Delete() {
+	name := c.GetString(":name")
+	cert, err := lib.FindRevokedCertByName(name)
+	if err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+
+	logs.Info("API: Deleting certificate: name=%s serial=%s", name, cert.Serial)
+	if err := lib.BurnCertificate(name, cert.Serial, certTFAName(cert)); err != nil {
+		c.ServeJSONError(err.Error())
+		return
+	}
+	c.ServeJSONMessage("Certificate \"" + name + "\" has been deleted")
+}
+
+func certTFAName(cert *lib.Cert) string {
+	if cert.Details == nil {
+		return ""
+	}
+	if cert.Details.TFAName == "" || cert.Details.TFAName == "none" {
+		return ""
+	}
+	return cert.Details.TFAName
+}
+
+func (c *APICertificatesController) fillCreateDefaults(req *APICreateCertRequest) error {
+	easyRSA := models.EasyRSAConfig{Profile: "default"}
+	if err := easyRSA.Read("Profile"); err != nil {
+		return err
+	}
+	clientCfg := models.OVClientConfig{Profile: "default"}
+	if err := clientCfg.Read("Profile"); err != nil {
+		return err
+	}
+
+	if req.ExpireDays == "" {
+		req.ExpireDays = strconv.Itoa(easyRSA.EasyRSACertExpire)
+	}
+	if req.Email == "" {
+		req.Email = easyRSA.EasyRSAReqEmail
+	}
+	if req.Country == "" {
+		req.Country = easyRSA.EasyRSAReqCountry
+	}
+	if req.Province == "" {
+		req.Province = easyRSA.EasyRSAReqProvince
+	}
+	if req.City == "" {
+		req.City = easyRSA.EasyRSAReqCity
+	}
+	if req.Org == "" {
+		req.Org = easyRSA.EasyRSAReqOrg
+	}
+	if req.OrgUnit == "" {
+		req.OrgUnit = easyRSA.EasyRSAReqOu
+	}
+	if req.TFAIssuer == "" {
+		req.TFAIssuer = clientCfg.TFAIssuer
+	}
+	return nil
+}
+
+func validateAPICreateCert(req APICreateCertRequest) error {
+	valid := validation.Validation{}
+	if ok, err := valid.Valid(&req); err != nil {
+		return err
+	} else if !ok {
+		return validationErr(valid)
+	}
+	return nil
+}
+
+func validationErr(valid validation.Validation) error {
+	for _, e := range valid.Errors {
+		return fmt.Errorf("%s: %s", e.Key, e.Message)
+	}
+	return fmt.Errorf("validation failed")
+}
+
+func apiSaveClientOVPN(configDir, name string) (string, error) {
+	cfg := clientconfig.New()
+	keysPath := filepath.Join(state.GlobalCfg.OVConfigPath, "pki/issued")
+	keysPathCa := filepath.Join(state.GlobalCfg.OVConfigPath, "pki")
+
+	ovClientConfig := &models.OVClientConfig{Profile: "default"}
+	if err := ovClientConfig.Read("Profile"); err != nil {
+		return "", err
+	}
+	cfg.ServerAddress = ovClientConfig.ServerAddress
+	cfg.OpenVpnServerPort = ovClientConfig.OpenVpnServerPort
+	cfg.AuthUserPass = ovClientConfig.AuthUserPass
+	cfg.ResolveRetry = ovClientConfig.ResolveRetry
+	cfg.OVClientUser = ovClientConfig.OVClientUser
+	cfg.OVClientGroup = ovClientConfig.OVClientGroup
+	cfg.PersistTun = ovClientConfig.PersistTun
+	cfg.PersistKey = ovClientConfig.PersistKey
+	cfg.RemoteCertTLS = ovClientConfig.RemoteCertTLS
+	cfg.RedirectGateway = ovClientConfig.RedirectGateway
+	cfg.Proto = ovClientConfig.Proto
+	cfg.Auth = ovClientConfig.Auth
+	cfg.Cipher = ovClientConfig.Cipher
+	cfg.Device = ovClientConfig.Device
+	cfg.AuthNoCache = ovClientConfig.AuthNoCache
+	cfg.TlsClient = ovClientConfig.TlsClient
+	cfg.Verbose = ovClientConfig.Verbose
+	cfg.CustomConfOne = ovClientConfig.CustomConfOne
+	cfg.CustomConfTwo = ovClientConfig.CustomConfTwo
+	cfg.CustomConfThree = ovClientConfig.CustomConfThree
+
+	ca, err := os.ReadFile(filepath.Join(keysPathCa, "ca.crt"))
+	if err != nil {
+		return "", err
+	}
+	cfg.Ca = string(ca)
+
+	ta, err := os.ReadFile(filepath.Join(keysPathCa, "ta.key"))
+	if err != nil {
+		return "", err
+	}
+	cfg.Ta = string(ta)
+
+	cert, err := os.ReadFile(filepath.Join(keysPath, name+".crt"))
+	if err != nil {
+		return "", err
+	}
+	cfg.Cert = string(cert)
+
+	keysPathKey := filepath.Join(state.GlobalCfg.OVConfigPath, "pki/private")
+	key, err := os.ReadFile(filepath.Join(keysPathKey, name+".key"))
+	if err != nil {
+		return "", err
+	}
+	cfg.Key = string(key)
+
+	serverConfig := models.OVConfig{Profile: "default"}
+	_ = serverConfig.Read("Profile")
+	cfg.Port = serverConfig.Port
+
+	destPath := filepath.Join(state.GlobalCfg.OVConfigPath, "clients", name+".ovpn")
+	if err := SaveToFile(filepath.Join(configDir, "openvpn-client-config.tpl"), cfg, destPath); err != nil {
+		logs.Error(err)
+		return "", err
+	}
+	return destPath, nil
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,12 @@
+# Features / 特性说明
+
+Documentation for features added beyond the core OpenVPN-UI functionality.
+
+本目录记录 OpenVPN-UI 在主线功能之外新增或扩展的特性文档。
+
+## Languages / 语言
+
+| Language | Index |
+|----------|-------|
+| English | [en/README.md](./en/README.md) |
+| 中文 | [zh/README.md](./zh/README.md) |

--- a/docs/features/en/README.md
+++ b/docs/features/en/README.md
@@ -1,0 +1,11 @@
+# Features
+
+Documentation for features added beyond the core OpenVPN-UI functionality.
+
+## Feature List
+
+| Feature | Document | Description |
+|---------|----------|-------------|
+| Certificate Management REST API | [certificate-api.md](./certificate-api.md) | Token-authenticated API for automated VPN account (certificate) management, designed for enterprise system integration |
+
+[中文](../zh/README.md)

--- a/docs/features/en/certificate-api.md
+++ b/docs/features/en/certificate-api.md
@@ -1,0 +1,372 @@
+# Certificate Management REST API
+
+## Background and Goals
+
+After deploying an internal OpenVPN service, enterprises often need to provision, renew, revoke, and distribute VPN credentials through their own business systems (such as OA portals, ops platforms, or employee self-service portals), rather than relying on administrators to use the web UI manually.
+
+This feature provides a **token-authenticated REST API** that covers the full certificate lifecycle, enabling enterprise systems to:
+
+- Automatically create VPN accounts and deliver `.ovpn` profiles when employees join
+- Revoke old certificates when employees leave or devices are replaced
+- Trigger certificate renewal before expiration via business workflows
+- Integrate VPN management with existing IAM, HR, or ticketing systems
+
+The API is independent of the web UI: the web interface uses session-based login, while the API uses a static token suitable for server-to-server calls.
+
+## Configuration
+
+### ApiToken
+
+Set in `conf/app.conf`:
+
+```ini
+ApiToken = "your-secret-api-token"
+```
+
+### Docker Environment Variable Override
+
+When deployed with Docker, the token can be overridden via environment variable (takes precedence over the config file):
+
+```yaml
+environment:
+  - OPENVPN_API_TOKEN=your-secret-api-token
+```
+
+If neither `ApiToken` nor `OPENVPN_API_TOKEN` is set, all API requests return `401`.
+
+## Authentication
+
+Every request must include one of the following headers:
+
+```http
+Authorization: Bearer your-secret-api-token
+```
+
+or:
+
+```http
+X-API-Token: your-secret-api-token
+```
+
+Authentication failure response:
+
+```json
+{
+  "status": "error",
+  "message": "Unauthorized"
+}
+```
+
+HTTP status code: `401`
+
+## General Information
+
+| Item | Value |
+|------|-------|
+| Base URL | `http://<host>:<port>/api/v1/certificates` |
+| Default port | `8080` (see `HttpPort` in `app.conf`) |
+| Content-Type | `application/json` (for POST / DELETE bodies) |
+| Response format | JSON (except `.ovpn` download) |
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/certificates` | Create certificate |
+| `GET` | `/api/v1/certificates/:name` | Download `.ovpn` profile |
+| `POST` | `/api/v1/certificates/:name/renew` | Renew certificate |
+| `POST` | `/api/v1/certificates/:name/revoke` | Revoke certificate |
+| `DELETE` | `/api/v1/certificates/:name` | Delete revoked certificate |
+
+> **About `name`**: `name` must be unique when creating a certificate; duplicate names are rejected. Use `name` as the stable account identifier in your business system (e.g. employee ID). Renew, revoke, and delete only need `name` in the URL path; the server resolves the matching certificate from the PKI index.
+
+---
+
+## Create Certificate
+
+Provision a VPN account for an employee or device.
+
+**Request**
+
+```http
+POST /api/v1/certificates
+Authorization: Bearer your-secret-api-token
+Content-Type: application/json
+```
+
+```json
+{
+  "name": "johndoe",
+  "staticip": "10.0.70.50",
+  "passphrase": "",
+  "expire_days": "825",
+  "email": "johndoe@company.com",
+  "country": "US",
+  "province": "California",
+  "city": "San Francisco",
+  "org": "MyCompany",
+  "org_unit": "IT",
+  "tfa_name": "",
+  "tfa_issuer": ""
+}
+```
+
+**Parameters**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Certificate name; must be unique; map to user ID or employee number in your system |
+| `staticip` | No | Static IP; leave empty for dynamic assignment |
+| `passphrase` | No | Private key passphrase |
+| `expire_days` | No | Validity in days; defaults to EasyRSA config |
+| `email` | No | Defaults to EasyRSA config |
+| `country` / `province` / `city` / `org` / `org_unit` | No | Certificate DN fields; default to EasyRSA config |
+| `tfa_name` / `tfa_issuer` | No | 2FA settings; leave empty for standard certificates |
+
+**Success response** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"johndoe\" has been created"
+}
+```
+
+**curl example**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates \
+  -H "Authorization: Bearer your-secret-api-token" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "johndoe", "email": "johndoe@company.com"}'
+```
+
+---
+
+## Download .ovpn Profile
+
+Retrieve the client connection configuration for delivery to employees or devices.
+
+**Request**
+
+```http
+GET /api/v1/certificates/johndoe
+Authorization: Bearer your-secret-api-token
+```
+
+**Success response** `200`
+
+Returns `.ovpn` file content:
+
+```http
+Content-Type: application/x-openvpn-profile
+Content-Disposition: attachment; filename="johndoe.ovpn"
+```
+
+**curl example**
+
+```bash
+curl -o johndoe.ovpn \
+  -H "Authorization: Bearer your-secret-api-token" \
+  http://localhost:8080/api/v1/certificates/johndoe
+```
+
+**Certificate not found** `404`
+
+```json
+{
+  "status": "error",
+  "message": "Certificate not found"
+}
+```
+
+---
+
+## Renew Certificate
+
+**Request**
+
+```http
+POST /api/v1/certificates/johndoe/renew
+Authorization: Bearer your-secret-api-token
+```
+
+No request body is required. The server looks up the active certificate by `name` and renews it.
+
+**curl example**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates/johndoe/renew \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**Success response** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"johndoe\" has been renewed"
+}
+```
+
+Renewal creates a new certificate with the same name. The old certificate remains in the list until revoked after the new profile is delivered.
+
+---
+
+## Revoke Certificate
+
+Use when an employee leaves or a device is decommissioned, preventing further VPN connections.
+
+**Request**
+
+```http
+POST /api/v1/certificates/johndoe/revoke
+Authorization: Bearer your-secret-api-token
+```
+
+No request body is required. The server looks up the active certificate by `name` and revokes it.
+
+**curl example**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates/johndoe/revoke \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**Success response** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"johndoe\" has been revoked"
+}
+```
+
+> Restart the OpenVPN service after revocation to immediately disconnect active clients (same behavior as the web UI).
+
+---
+
+## Delete Certificate
+
+Permanently remove a **revoked** certificate record.
+
+**Request**
+
+```http
+DELETE /api/v1/certificates/johndoe
+Authorization: Bearer your-secret-api-token
+```
+
+No request body is required. The server looks up the revoked certificate by `name` and deletes it.
+
+**curl example**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/certificates/johndoe \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**Success response** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"johndoe\" has been deleted"
+}
+```
+
+---
+
+## Error Responses
+
+Except for the download endpoint, errors are returned as JSON:
+
+```json
+{
+  "status": "error",
+  "message": "error description"
+}
+```
+
+| HTTP status | Meaning |
+|-------------|---------|
+| `400` | Invalid parameters or operation failure |
+| `401` | Missing or invalid token |
+| `404` | Certificate not found (download endpoint) |
+
+---
+
+## Typical Enterprise Integration Flows
+
+### Employee Onboarding
+
+```
+Business system ──POST /certificates──▶ Create certificate
+                ◀── 200 success ────────
+                ──GET /certificates/:name──▶ Download .ovpn
+                ◀── .ovpn file ───────────
+                ── Store in object storage / email / portal download
+```
+
+### Employee Offboarding
+
+```
+Business system ──POST /certificates/:name/revoke──▶ Revoke certificate
+                ──DELETE /certificates/:name───────▶ Clean up record (optional)
+                ── Notify ops to restart OpenVPN (if immediate disconnect needed)
+```
+
+### Certificate Renewal
+
+```
+Business system ──POST /certificates/:name/renew──▶ Renew
+                ──GET /certificates/:name─────────▶ Fetch new .ovpn
+                ──POST /certificates/:name/revoke──▶ Revoke old cert (optional)
+```
+
+We recommend maintaining a VPN account ledger in your business system with at least:
+
+| Field | Description |
+|-------|-------------|
+| `user_id` | User identifier in your system |
+| `cert_name` | Corresponds to API `name` |
+| `status` | active / revoked |
+
+---
+
+## API Verification Tool
+
+A built-in verification program is included for smoke and integration testing:
+
+```bash
+# Smoke tests (auth, routing, validation)
+go run ./cmd/verify-api
+
+# Custom base URL and token
+go run ./cmd/verify-api \
+  -base http://localhost:8080 \
+  -token your-secret-api-token
+
+# Full lifecycle tests (requires complete PKI environment)
+go run ./cmd/verify-api -integration
+```
+
+Build as a standalone tool:
+
+```bash
+go build -o verify-api ./cmd/verify-api
+./verify-api
+```
+
+---
+
+## Related Code
+
+| File | Description |
+|------|-------------|
+| `controllers/api-certificates.go` | API controller |
+| `controllers/api-base.go` | Token authentication |
+| `routers/router.go` | Route registration |
+| `cmd/verify-api/main.go` | API verification tool |
+
+[中文版本](../zh/certificate-api.md)

--- a/docs/features/zh/README.md
+++ b/docs/features/zh/README.md
@@ -1,0 +1,11 @@
+# 特性说明
+
+本目录记录 OpenVPN-UI 新增或扩展的特性文档。
+
+## 特性列表
+
+| 特性 | 文档 | 说明 |
+|------|------|------|
+| 证书管理 REST API | [certificate-api.md](./certificate-api.md) | 面向企业业务系统的 VPN 账号（证书）自动化管理接口 |
+
+[English](../en/README.md)

--- a/docs/features/zh/certificate-api.md
+++ b/docs/features/zh/certificate-api.md
@@ -1,0 +1,372 @@
+# 证书管理 REST API
+
+## 背景与目标
+
+企业部署内部 OpenVPN 后，往往需要将 VPN 账号的开通、续期、吊销与配置下发，纳入自有业务系统（如 OA、运维平台、员工门户）统一编排，而不是让管理员手工登录 Web 界面操作。
+
+本特性提供一套 **Token 鉴权的 REST API**，覆盖证书全生命周期管理，使企业系统可以：
+
+- 员工入职时自动创建 VPN 账号并下发 `.ovpn` 配置
+- 员工离职或设备更换时自动吊销旧证书
+- 证书到期前通过业务系统触发续期
+- 将 VPN 管理流程与现有 IAM / HR / 工单系统对接
+
+API 与 Web 管理界面相互独立：Web 仍使用 Session 登录；API 使用固定 Token，适合服务端对服务端调用。
+
+## 配置
+
+### ApiToken
+
+在 `conf/app.conf` 中配置：
+
+```ini
+ApiToken = "your-secret-api-token"
+```
+
+### Docker 环境变量覆盖
+
+Docker 部署时可通过环境变量覆盖（优先级高于配置文件）：
+
+```yaml
+environment:
+  - OPENVPN_API_TOKEN=your-secret-api-token
+```
+
+未配置 `ApiToken` 且未设置 `OPENVPN_API_TOKEN` 时，所有 API 请求将返回 `401`。
+
+## 鉴权
+
+每个请求须携带以下任一 Header：
+
+```http
+Authorization: Bearer your-secret-api-token
+```
+
+或：
+
+```http
+X-API-Token: your-secret-api-token
+```
+
+鉴权失败响应：
+
+```json
+{
+  "status": "error",
+  "message": "Unauthorized"
+}
+```
+
+HTTP 状态码：`401`
+
+## 基础信息
+
+| 项目 | 值 |
+|------|-----|
+| Base URL | `http://<host>:<port>/api/v1/certificates` |
+| 默认端口 | `8080`（以 `app.conf` 中 `HttpPort` 为准） |
+| Content-Type | `application/json`（POST / DELETE 请求体） |
+| 响应格式 | JSON（下载 `.ovpn` 除外） |
+
+## 接口一览
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `POST` | `/api/v1/certificates` | 创建证书 |
+| `GET` | `/api/v1/certificates/:name` | 下载 `.ovpn` 配置 |
+| `POST` | `/api/v1/certificates/:name/renew` | 续期证书 |
+| `POST` | `/api/v1/certificates/:name/revoke` | 吊销证书 |
+| `DELETE` | `/api/v1/certificates/:name` | 删除已吊销的证书 |
+
+> **关于 `name`**：创建时 `name` 必须唯一，已存在同名证书则无法再次创建。业务系统可用 `name` 作为稳定账号标识（如工号）。续期、吊销、删除只需在 URL 路径中传入 `name`，服务端会自动从 PKI 索引解析对应证书。
+
+---
+
+## 创建证书
+
+为员工或设备开通 VPN 账号。
+
+**请求**
+
+```http
+POST /api/v1/certificates
+Authorization: Bearer your-secret-api-token
+Content-Type: application/json
+```
+
+```json
+{
+  "name": "zhangsan",
+  "staticip": "10.0.70.50",
+  "passphrase": "",
+  "expire_days": "825",
+  "email": "zhangsan@company.com",
+  "country": "CN",
+  "province": "Beijing",
+  "city": "Beijing",
+  "org": "MyCompany",
+  "org_unit": "IT",
+  "tfa_name": "",
+  "tfa_issuer": ""
+}
+```
+
+**参数说明**
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `name` | 是 | 证书名称，必须唯一，建议与业务系统用户 ID 或工号对应 |
+| `staticip` | 否 | 静态 IP，留空则动态分配 |
+| `passphrase` | 否 | 私钥密码 |
+| `expire_days` | 否 | 有效期（天），默认取 EasyRSA 配置 |
+| `email` | 否 | 默认取 EasyRSA 配置 |
+| `country` / `province` / `city` / `org` / `org_unit` | 否 | 证书 DN 字段，默认取 EasyRSA 配置 |
+| `tfa_name` / `tfa_issuer` | 否 | 2FA 相关，留空表示普通证书 |
+
+**成功响应** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"zhangsan\" has been created"
+}
+```
+
+**curl 示例**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates \
+  -H "Authorization: Bearer your-secret-api-token" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "zhangsan", "email": "zhangsan@company.com"}'
+```
+
+---
+
+## 下载 .ovpn 配置
+
+获取客户端连接配置文件，可下发给员工或设备。
+
+**请求**
+
+```http
+GET /api/v1/certificates/zhangsan
+Authorization: Bearer your-secret-api-token
+```
+
+**成功响应** `200`
+
+返回 `.ovpn` 文件内容：
+
+```http
+Content-Type: application/x-openvpn-profile
+Content-Disposition: attachment; filename="zhangsan.ovpn"
+```
+
+**curl 示例**
+
+```bash
+curl -o zhangsan.ovpn \
+  -H "Authorization: Bearer your-secret-api-token" \
+  http://localhost:8080/api/v1/certificates/zhangsan
+```
+
+**证书不存在** `404`
+
+```json
+{
+  "status": "error",
+  "message": "Certificate not found"
+}
+```
+
+---
+
+## 续期证书
+
+**请求**
+
+```http
+POST /api/v1/certificates/zhangsan/renew
+Authorization: Bearer your-secret-api-token
+```
+
+无需请求体，服务端根据 `name` 查找当前有效证书并续期。
+
+**curl 示例**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates/zhangsan/renew \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**成功响应** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"zhangsan\" has been renewed"
+}
+```
+
+续期后会生成同名新证书，旧证书仍在列表中，待新配置下发后可再次调用吊销接口。
+
+---
+
+## 吊销证书
+
+用于员工离职、设备报废等场景，使证书无法再连接 VPN。
+
+**请求**
+
+```http
+POST /api/v1/certificates/zhangsan/revoke
+Authorization: Bearer your-secret-api-token
+```
+
+无需请求体，服务端根据 `name` 查找当前有效证书并吊销。
+
+**curl 示例**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/certificates/zhangsan/revoke \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**成功响应** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"zhangsan\" has been revoked"
+}
+```
+
+> 吊销后需重启 OpenVPN 服务才能立即断开已连接客户端（与 Web 界面行为一致）。
+
+---
+
+## 删除证书
+
+永久移除**已吊销**的证书记录。
+
+**请求**
+
+```http
+DELETE /api/v1/certificates/zhangsan
+Authorization: Bearer your-secret-api-token
+```
+
+无需请求体，服务端根据 `name` 查找已吊销的证书记录并删除。
+
+**curl 示例**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/certificates/zhangsan \
+  -H "Authorization: Bearer your-secret-api-token"
+```
+
+**成功响应** `200`
+
+```json
+{
+  "status": "success",
+  "message": "Certificate \"zhangsan\" has been deleted"
+}
+```
+
+---
+
+## 错误响应
+
+除下载接口返回文件外，错误统一为 JSON：
+
+```json
+{
+  "status": "error",
+  "message": "错误描述"
+}
+```
+
+| HTTP 状态码 | 含义 |
+|-------------|------|
+| `400` | 参数错误或业务操作失败 |
+| `401` | Token 缺失或无效 |
+| `404` | 证书不存在（下载接口） |
+
+---
+
+## 企业集成典型流程
+
+### 员工入职
+
+```
+业务系统 ──POST /certificates──▶ 创建证书
+         ◀── 200 success ────────
+         ──GET /certificates/:name──▶ 下载 .ovpn
+         ◀── .ovpn 文件 ───────────
+         ── 存入对象存储 / 邮件下发 / 门户下载
+```
+
+### 员工离职
+
+```
+业务系统 ──POST /certificates/:name/revoke──▶ 吊销证书
+         ──DELETE /certificates/:name───────▶ 清理记录（可选）
+         ── 通知运维重启 OpenVPN（如需立即断连）
+```
+
+### 证书续期
+
+```
+业务系统 ──POST /certificates/:name/renew──▶ 续期
+         ──GET /certificates/:name─────────▶ 获取新 .ovpn
+         ──POST /certificates/:name/revoke──▶ 吊销旧证（可选）
+```
+
+建议业务系统维护一张 VPN 账号台账，至少记录：
+
+| 字段 | 说明 |
+|------|------|
+| `user_id` | 业务系统用户标识 |
+| `cert_name` | 对应 API 中的 `name` |
+| `status` | active / revoked |
+
+---
+
+## API 验证工具
+
+项目内置验证程序，可用于冒烟测试或集成测试：
+
+```bash
+# 冒烟测试（鉴权、路由、参数校验）
+go run ./cmd/verify-api
+
+# 指定地址和 Token
+go run ./cmd/verify-api \
+  -base http://localhost:8080 \
+  -token your-secret-api-token
+
+# 完整生命周期测试（需完整 PKI 环境）
+go run ./cmd/verify-api -integration
+```
+
+编译为独立工具：
+
+```bash
+go build -o verify-api ./cmd/verify-api
+./verify-api
+```
+
+---
+
+## 相关代码
+
+| 文件 | 说明 |
+|------|------|
+| `controllers/api-certificates.go` | API 控制器 |
+| `controllers/api-base.go` | Token 鉴权 |
+| `routers/router.go` | 路由注册 |
+| `cmd/verify-api/main.go` | API 验证程序 |
+
+[English version](../en/certificate-api.md)

--- a/lib/certificates.go
+++ b/lib/certificates.go
@@ -115,6 +115,52 @@ func trim(s string) string {
 	return strings.Trim(strings.Trim(s, "\r\n"), "\n")
 }
 
+func certIndexPath() string {
+	return state.GlobalCfg.OVConfigPath + "/pki/index.txt"
+}
+
+// FindActiveCertByName returns the latest valid certificate for name.
+func FindActiveCertByName(name string) (*Cert, error) {
+	certs, err := ReadCerts(certIndexPath())
+	if err != nil {
+		return nil, err
+	}
+	var found *Cert
+	for _, cert := range certs {
+		if cert.Details == nil || cert.Details.Name != name {
+			continue
+		}
+		if cert.EntryType == "V" && cert.Revocation == "" {
+			found = cert
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("active certificate for %q not found", name)
+	}
+	return found, nil
+}
+
+// FindRevokedCertByName returns the latest revoked certificate for name.
+func FindRevokedCertByName(name string) (*Cert, error) {
+	certs, err := ReadCerts(certIndexPath())
+	if err != nil {
+		return nil, err
+	}
+	var found *Cert
+	for _, cert := range certs {
+		if cert.Details == nil || cert.Details.Name != name {
+			continue
+		}
+		if cert.EntryType == "R" || cert.Revocation != "" {
+			found = cert
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("revoked certificate for %q not found", name)
+	}
+	return found, nil
+}
+
 func CreateCertificate(name string, staticip string, passphrase string, expiredays string, email string, country string, province string, city string, org string, orgunit string, tfaname string, tfaissuer string) error {
 	logs.Info("Lib: Creating certificate with parameters: name=%s, staticip=%s, passphrase=%s, expiredays=%s, email=%s, country=%s, province=%s, city=%s, org=%s, orgunit=%s, tfaname=%s, tfaissuer=%s", name, staticip, passphrase, expiredays, email, country, province, city, org, orgunit, tfaname, tfaissuer)
 	path := state.GlobalCfg.OVConfigPath + "/pki/index.txt"

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -6,6 +6,46 @@ import (
 
 func init() {
 
+	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"] =
+		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"],
+			web.ControllerComments{
+				Method:           "Get",
+				Router:           `/:name`,
+				AllowHTTPMethods: []string{"get"},
+				Params:           nil})
+
+	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"] =
+		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"],
+			web.ControllerComments{
+				Method:           "Create",
+				Router:           `/`,
+				AllowHTTPMethods: []string{"post"},
+				Params:           nil})
+
+	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"] =
+		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"],
+			web.ControllerComments{
+				Method:           "Renew",
+				Router:           `/:name/renew`,
+				AllowHTTPMethods: []string{"post"},
+				Params:           nil})
+
+	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"] =
+		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"],
+			web.ControllerComments{
+				Method:           "Revoke",
+				Router:           `/:name/revoke`,
+				AllowHTTPMethods: []string{"post"},
+				Params:           nil})
+
+	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"] =
+		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APICertificatesController"],
+			web.ControllerComments{
+				Method:           "Delete",
+				Router:           `/:name`,
+				AllowHTTPMethods: []string{"delete"},
+				Params:           nil})
+
 	web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APISessionController"] =
 		append(web.GlobalControllerRouter["github.com/d3vilh/openvpn-ui/controllers:APISessionController"],
 			web.ControllerComments{

--- a/routers/router.go
+++ b/routers/router.go
@@ -49,6 +49,11 @@ func Init(configDir string) {
 				&controllers.APISignalController{},
 			),
 		),
+		web.NSNamespace("/certificates",
+			web.NSInclude(
+				&controllers.APICertificatesController{ConfigDir: configDir},
+			),
+		),
 	)
 	web.AddNamespace(ns)
 }


### PR DESCRIPTION
- Introduced APICertificatesController for managing OpenVPN client certificates.
- Implemented endpoints for creating, renewing, revoking, and deleting certificates.
- Added API token validation in APITokenController.
- Updated app configuration to include ApiToken setting.
- Enhanced documentation for the new API features in both English and Chinese.
- Added a verification tool for API testing.